### PR TITLE
Chore: add auth preference

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -115,6 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
       }];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
+          authenticationVC.prefersEphemeralWebBrowserSession = true;
           authenticationVC.presentationContextProvider = self;
       }
 #endif


### PR DESCRIPTION
## What

Disables permissions dialog

## Why

For our Auth flow, we do not require the ios permissions dialog modal

## Type of change

Please delete options that are not relevant.

- [x] Chore (non-breaking minor change i.e. copy adjustments)
